### PR TITLE
Allow a delay of 0 (zero)

### DIFF
--- a/packages/vite-plugin-watch-and-run/src/index.ts
+++ b/packages/vite-plugin-watch-and-run/src/index.ts
@@ -56,7 +56,7 @@ function checkConf(params: Options[]) {
 
 		paramsChecked[param.watch] = {
 			run: param.run,
-			delay: param.delay || 500,
+			delay: param.delay ?? 500,
 			isRunnig: false
 		};
 	}


### PR DESCRIPTION
Using a logical `OR` restricts falsey values, thus `0` is not valid. Changing to the nullish coalescing operator `??` allows `0`.