### PR TITLE
Updated .graphqlrc.yaml to reflect correct schema location

### DIFF
--- a/website/docs/all-in.mdx
+++ b/website/docs/all-in.mdx
@@ -94,7 +94,7 @@ export default config;
 import { KitQLClient } from '@kitql/client';
 
 export const kitQLClient = new KitQLClient({
-        // The URL is the Graphql endpoint KitQL will use to make requests
+	// The URL is the Graphql endpoint KitQL will use to make requests
 	url: `https://countries.trevorblades.com/graphql`,
 	headersContentType: 'application/json',
 	logType: ['client', 'server', 'operationAndvariables']

--- a/website/docs/all-in.mdx
+++ b/website/docs/all-in.mdx
@@ -20,7 +20,12 @@ sidebar_label: Getting started => All-In
 projects:
   default:
     schema:
-      - ./src/lib/graphql/schema.json
+      # This can be a relative path from this file to a schema,
+      # a URL to a graphql endpoint, an intorspection JSON file,
+      # and many more options. Refer to:
+      # refer to https://www.graphql-code-generator.com/docs/config-reference/schema-field
+      # for more information
+      - https://countries.trevorblades.com/graphql
     documents:
       - '**/*.gql'
 	extensions:
@@ -89,6 +94,7 @@ export default config;
 import { KitQLClient } from '@kitql/client';
 
 export const kitQLClient = new KitQLClient({
+        // The URL is the Graphql endpoint KitQL will use to make requests
 	url: `https://countries.trevorblades.com/graphql`,
 	headersContentType: 'application/json',
 	logType: ['client', 'server', 'operationAndvariables']


### PR DESCRIPTION
I updated the `.graphqlrc.yaml` file to reflect the same schema location (URL) as is used in the `KitQLClient` file for consistency through the process and to avoid errors. I also added comments to educate new users on what the `schema` field and the URL in the client are used for. 

Also note that I was not able to get the walkthrough working with these changes alone - reference [issue https://github.com/jycouet/kitql/issues/132](https://github.com/jycouet/kitql/issues/132) for further info