### PR TITLE
[Watch & Run] Add missing hooks

### DIFF
--- a/.changeset/twelve-panthers-love.md
+++ b/.changeset/twelve-panthers-love.md
@@ -1,0 +1,5 @@
+---
+"@kitql/vite-plugin-watch-and-run": minor
+---
+
+BREAKING: ADD, CHANGE, DELETE were renamed add, change, delete

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ You have 3 main options to use `KitQL`:
 ## ✨ Contributors
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-17-orange.svg)](#contributors)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ You have 3 main options to use `KitQL`:
 ## ✨ Contributors
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-16-orange.svg)](#contributors)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/packages/vite-plugin-watch-and-run/src/index.ts
+++ b/packages/vite-plugin-watch-and-run/src/index.ts
@@ -26,9 +26,9 @@ export type Options = {
   name?: string | null
 }
 
-const kindWithPath = ['add', 'addDir', 'change', 'delete', 'unlink', 'unlinkDir'] as const
+export const kindWithPath = ['add', 'addDir', 'change', 'delete', 'unlink', 'unlinkDir'] as const
 export type KindWithPath = typeof kindWithPath[number]
-const kindWithoutPath = ['all', 'error', 'raw', 'ready'] as const
+export const kindWithoutPath = ['all', 'error', 'raw', 'ready'] as const
 export type KindWithoutPath = typeof kindWithoutPath[number]
 export type WatchKind = KindWithPath | KindWithoutPath
 

--- a/packages/vite-plugin-watch-and-run/src/index.ts
+++ b/packages/vite-plugin-watch-and-run/src/index.ts
@@ -55,6 +55,7 @@ function checkConf(params: Options[]) {
       throw new Error('plugin watch-and-run, `run` is missing.')
     }
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore (because the config is in a js file, and people maybe didn't update their config.)
     if (param.watchKind === 'ADD' || param.watchKind === 'CHANGE' || param.watchKind === 'DELETE') {
       throw new Error('BREAKING: ADD, CHANGE, DELETE were renamed add, change, delete. Please update your config.')

--- a/packages/vite-plugin-watch-and-run/src/index.ts
+++ b/packages/vite-plugin-watch-and-run/src/index.ts
@@ -1,165 +1,191 @@
-import { Log, logCyan, logGreen, logMagneta, logRed } from '@kitql/helper'
-import { spawn } from 'child_process'
-import micromatch from 'micromatch'
+import { Log, logCyan, logGreen, logMagneta, logRed } from "@kitql/helper";
+import { spawn } from "child_process";
+import micromatch from "micromatch";
 
 export type Options = {
   /**
    * watch files to trigger the run action (glob format)
    */
-  watch: string
+  watch: string;
   /**
    * Kind of watch that will trigger the run action
    */
-  watchKind?: WatchKind[]
+  watchKind?: WatchKind[];
   /**
    * run command (yarn gen for example!)
    */
-  run: string
+  run: string;
   /**
    * Delay before running the run command (in ms)
    * @default 300 ms
    */
-  delay?: number | null
+  delay?: number | null;
   /**
    * Name to display in the logs as prefix
    */
-  name?: string | null
-}
+  name?: string | null;
+};
 
-export const kindWithPath = ['add', 'addDir', 'change', 'delete', 'unlink', 'unlinkDir'] as const
-export type KindWithPath = typeof kindWithPath[number]
-export const kindWithoutPath = ['all', 'error', 'raw', 'ready'] as const
-export type KindWithoutPath = typeof kindWithoutPath[number]
-export type WatchKind = KindWithPath | KindWithoutPath
+export const kindWithPath = [
+  "add",
+  "addDir",
+  "change",
+  "delete",
+  "unlink",
+  "unlinkDir"
+] as const;
+export type KindWithPath = typeof kindWithPath[number];
+export const kindWithoutPath = ["all", "error", "raw", "ready"] as const;
+export type KindWithoutPath = typeof kindWithoutPath[number];
+export type WatchKind = KindWithPath | KindWithoutPath;
 
 export type StateDetail = {
-  kind: WatchKind[]
-  run: string
-  delay: number
-  isRunning: boolean
-  name?: string | null
-}
+  kind: WatchKind[];
+  run: string;
+  delay: number;
+  isRunning: boolean;
+  name?: string | null;
+};
 
 function checkConf(params: Options[]) {
   if (!Array.isArray(params)) {
-    throw new Error('plugin watchAndRun, `params` needs to be an array.')
+    throw new Error("plugin watchAndRun, `params` needs to be an array.");
   }
 
-  const paramsChecked: Record<string, StateDetail> = {}
+  const paramsChecked: Record<string, StateDetail> = {};
 
   params.forEach(param => {
     if (!param.watch) {
-      throw new Error('plugin watch-and-run, `watch` is missing.')
+      throw new Error("plugin watch-and-run, `watch` is missing.");
     }
     if (!param.run) {
-      throw new Error('plugin watch-and-run, `run` is missing.')
+      throw new Error("plugin watch-and-run, `run` is missing.");
     }
 
     paramsChecked[param.watch] = {
-      kind: param.watchKind ?? ['add', 'change', 'delete'],
+      kind: param.watchKind ?? ["add", "change", "delete"],
       run: param.run,
       delay: param.delay ?? 300,
       isRunning: false,
-      name: param.name,
-    }
-  })
+      name: param.name
+    };
+  });
 
-  return paramsChecked
+  return paramsChecked;
 }
 
-type ShouldRunResult = 
-  | { shouldRun: true, globToWatch: string, param: StateDetail }
-  | { shouldRun: false, globToWatch: null, param: null }
+type ShouldRunResult =
+  | { shouldRun: true; globToWatch: string; param: StateDetail }
+  | { shouldRun: false; globToWatch: null; param: null };
 function shouldRun(
   absolutePath: string | null,
   watchKind: WatchKind,
   watchAndRunConf: Record<string, StateDetail>
 ): ShouldRunResult {
   for (const [globToWatch, param] of Object.entries(watchAndRunConf)) {
-    const isWatched = param.kind.includes(watchKind)
-    const isPathMatching = absolutePath && micromatch.isMatch(absolutePath, globToWatch)
-    const isWatchKindWithoutPath = kindWithoutPath.includes(watchKind as KindWithoutPath)
-    if (!param.isRunning && isWatched && (isPathMatching || isWatchKindWithoutPath)) {
+    const isWatched = param.kind.includes(watchKind);
+    const isPathMatching =
+      absolutePath && micromatch.isMatch(absolutePath, globToWatch);
+    const isWatchKindWithoutPath = kindWithoutPath.includes(
+      watchKind as KindWithoutPath
+    );
+    if (
+      !param.isRunning &&
+      isWatched &&
+      (isPathMatching || isWatchKindWithoutPath)
+    ) {
       return {
         shouldRun: true,
         globToWatch,
-        param,
-      }
+        param
+      };
     }
   }
   return {
     shouldRun: false,
     globToWatch: null,
-    param: null,
-  }
+    param: null
+  };
 }
 
 function formatLog(str: string, name?: string) {
-  return `${name ? logMagneta(`[${name}]`) : ''} ${str}`
+  return `${name ? logMagneta(`[${name}]`) : ""} ${str}`;
 }
 
-async function watcher(absolutePath: string | null, watchKind: WatchKind, watchAndRunConf: Record<string, StateDetail>) {
-  const shouldRunInfo = shouldRun(absolutePath, watchKind, watchAndRunConf)
+async function watcher(
+  absolutePath: string | null,
+  watchKind: WatchKind,
+  watchAndRunConf: Record<string, StateDetail>
+) {
+  const shouldRunInfo = shouldRun(absolutePath, watchKind, watchAndRunConf);
   if (shouldRunInfo.shouldRun) {
-    watchAndRunConf[shouldRunInfo.globToWatch].isRunning = true
+    watchAndRunConf[shouldRunInfo.globToWatch].isRunning = true;
 
     log.info(
-      `${logGreen('✔')} Thx to ${logGreen(shouldRunInfo.globToWatch)}, ` +
-        `triggered by ${logCyan(watchKind)} ${absolutePath && logGreen(absolutePath)}, ` +
-        `we will wait ${logCyan(shouldRunInfo.param.delay + 'ms')} and run ${logGreen(shouldRunInfo.param.run)}.`
-    )
+      `${logGreen("✔")} Thx to ${logGreen(shouldRunInfo.globToWatch)}, ` +
+        `triggered by ${logCyan(watchKind)} ${absolutePath &&
+          logGreen(absolutePath)}, ` +
+        `we will wait ${logCyan(
+          shouldRunInfo.param.delay + "ms"
+        )} and run ${logGreen(shouldRunInfo.param.run)}.`
+    );
 
     // Run after a delay
     setTimeout(() => {
-      const child = spawn(shouldRunInfo.param.run, [], { shell: true })
+      const child = spawn(shouldRunInfo.param.run, [], { shell: true });
 
       //spit stdout to screen
-      child.stdout.on('data', data => {
-        process.stdout.write(formatLog(data.toString(), shouldRunInfo.param.name ?? ''))
-      })
+      child.stdout.on("data", data => {
+        process.stdout.write(
+          formatLog(data.toString(), shouldRunInfo.param.name ?? "")
+        );
+      });
 
       //spit stderr to screen
-      child.stderr.on('data', data => {
-        process.stdout.write(formatLog(data.toString(), shouldRunInfo.param.name ?? ''))
-      })
+      child.stderr.on("data", data => {
+        process.stdout.write(
+          formatLog(data.toString(), shouldRunInfo.param.name ?? "")
+        );
+      });
 
-      child.on('close', code => {
+      child.on("close", code => {
         if (code === 0) {
-          log.info(`${logGreen('✔')} finished ${logGreen('successfully')}`)
+          log.info(`${logGreen("✔")} finished ${logGreen("successfully")}`);
         } else {
-          log.error(`finished with some ${logRed('errors')}`)
+          log.error(`finished with some ${logRed("errors")}`);
         }
-        shouldRunInfo.param.isRunning = false
-      })
+        shouldRunInfo.param.isRunning = false;
+      });
 
-      return
-    }, shouldRunInfo.param.delay)
+      return;
+    }, shouldRunInfo.param.delay);
   }
 
-  return
+  return;
 }
 
-const log = new Log('KitQL vite-plugin-watch-and-run')
+const log = new Log("KitQL vite-plugin-watch-and-run");
 
 export default function watchAndRun(params: Options[]) {
   // check params, throw Errors if not valid and return a new object representing the state of the plugin
-  const watchAndRunConf = checkConf(params)
+  const watchAndRunConf = checkConf(params);
 
   return {
-    name: 'watch-and-run',
+    name: "watch-and-run",
 
     watchAndRunConf,
 
     configureServer(server) {
       kindWithPath.forEach((kind: KindWithPath) => {
-        const _watcher = async (absolutePath: string) => watcher(absolutePath, kind, watchAndRunConf)
-        server.watcher.on(kind, _watcher)
-      })
+        const _watcher = async (absolutePath: string) =>
+          watcher(absolutePath, kind, watchAndRunConf);
+        server.watcher.on(kind, _watcher);
+      });
 
       kindWithoutPath.forEach((kind: KindWithoutPath) => {
-        const _watcher = () => watcher(null, kind, watchAndRunConf)
-        server.watcher.on(kind, _watcher)
-      })
-    },
-  }
+        const _watcher = () => watcher(null, kind, watchAndRunConf);
+        server.watcher.on(kind, _watcher);
+      });
+    }
+  };
 }

--- a/packages/vite-plugin-watch-and-run/src/index.ts
+++ b/packages/vite-plugin-watch-and-run/src/index.ts
@@ -26,10 +26,14 @@ export type Options = {
   name?: string | null
 }
 
-export type WatchKind = 'ADD' | 'CHANGE' | 'DELETE'
+const kindWithPath = ['add', 'addDir', 'change', 'delete', 'unlink', 'unlinkDir'] as const
+export type KindWithPath = typeof kindWithPath[number]
+const kindWithoutPath = ['all', 'error', 'raw', 'ready'] as const
+export type KindWithoutPath = typeof kindWithoutPath[number]
+export type WatchKind = KindWithPath | KindWithoutPath
 
 export type StateDetail = {
-  kind: ('ADD' | 'CHANGE' | 'DELETE')[]
+  kind: WatchKind[]
   run: string
   delay: number
   isRunning: boolean
@@ -43,8 +47,7 @@ function checkConf(params: Options[]) {
 
   const paramsChecked: Record<string, StateDetail> = {}
 
-  for (let i = 0; i < params.length; i++) {
-    const param = params[i]
+  params.forEach(param => {
     if (!param.watch) {
       throw new Error('plugin watch-and-run, `watch` is missing.')
     }
@@ -53,21 +56,30 @@ function checkConf(params: Options[]) {
     }
 
     paramsChecked[param.watch] = {
-      kind: param.watchKind ?? ['ADD', 'CHANGE', 'DELETE'],
+      kind: param.watchKind ?? ['add', 'change', 'delete'],
       run: param.run,
       delay: param.delay ?? 300,
       isRunning: false,
       name: param.name,
     }
-  }
+  })
 
   return paramsChecked
 }
 
-async function shouldRun(absolutePath: string, watchKind: WatchKind, watchAndRunConf: Record<string, StateDetail>) {
-  for (const globToWatch in watchAndRunConf) {
-    const param = watchAndRunConf[globToWatch]
-    if (!param.isRunning && param.kind.includes(watchKind) && micromatch.isMatch(absolutePath, globToWatch)) {
+type ShouldRunResult = 
+  | { shouldRun: true, globToWatch: string, param: StateDetail }
+  | { shouldRun: false, globToWatch: null, param: null }
+function shouldRun(
+  absolutePath: string | null,
+  watchKind: WatchKind,
+  watchAndRunConf: Record<string, StateDetail>
+): ShouldRunResult {
+  for (const [globToWatch, param] of Object.entries(watchAndRunConf)) {
+    const isWatched = param.kind.includes(watchKind)
+    const isPathMatching = absolutePath && micromatch.isMatch(absolutePath, globToWatch)
+    const isWatchKindWithoutPath = kindWithoutPath.includes(watchKind as KindWithoutPath)
+    if (!param.isRunning && isWatched && (isPathMatching || isWatchKindWithoutPath)) {
       return {
         shouldRun: true,
         globToWatch,
@@ -86,14 +98,14 @@ function formatLog(str: string, name?: string) {
   return `${name ? logMagneta(`[${name}]`) : ''} ${str}`
 }
 
-async function watcher(absolutePath: string, watchKind: WatchKind, watchAndRunConf: Record<string, StateDetail>) {
-  const shouldRunInfo = await shouldRun(absolutePath, watchKind, watchAndRunConf)
+async function watcher(absolutePath: string | null, watchKind: WatchKind, watchAndRunConf: Record<string, StateDetail>) {
+  const shouldRunInfo = shouldRun(absolutePath, watchKind, watchAndRunConf)
   if (shouldRunInfo.shouldRun) {
     watchAndRunConf[shouldRunInfo.globToWatch].isRunning = true
 
     log.info(
       `${logGreen('✔')} Thx to ${logGreen(shouldRunInfo.globToWatch)}, ` +
-        `triggered by ${logCyan(watchKind)} ${logGreen(absolutePath)}, ` +
+        `triggered by ${logCyan(watchKind)} ${absolutePath && logGreen(absolutePath)}, ` +
         `we will wait ${logCyan(shouldRunInfo.param.delay + 'ms')} and run ${logGreen(shouldRunInfo.param.run)}.`
     )
 
@@ -103,12 +115,12 @@ async function watcher(absolutePath: string, watchKind: WatchKind, watchAndRunCo
 
       //spit stdout to screen
       child.stdout.on('data', data => {
-        process.stdout.write(formatLog(data.toString(), shouldRunInfo.param.name))
+        process.stdout.write(formatLog(data.toString(), shouldRunInfo.param.name ?? ''))
       })
 
       //spit stderr to screen
       child.stderr.on('data', data => {
-        process.stdout.write(formatLog(data.toString(), shouldRunInfo.param.name))
+        process.stdout.write(formatLog(data.toString(), shouldRunInfo.param.name ?? ''))
       })
 
       child.on('close', code => {
@@ -139,19 +151,15 @@ export default function watchAndRun(params: Options[]) {
     watchAndRunConf,
 
     configureServer(server) {
-      const watcherAdd = async absolutePath => {
-        watcher(absolutePath, 'ADD', watchAndRunConf)
-      }
-      const watcherChange = async absolutePath => {
-        watcher(absolutePath, 'CHANGE', watchAndRunConf)
-      }
-      const watcherDelete = async absolutePath => {
-        watcher(absolutePath, 'DELETE', watchAndRunConf)
-      }
+      kindWithPath.forEach((kind: KindWithPath) => {
+        const _watcher = async (absolutePath: string) => watcher(absolutePath, kind, watchAndRunConf)
+        server.watcher.on(kind, _watcher)
+      })
 
-      server.watcher.on('add', watcherAdd)
-      server.watcher.on('change', watcherChange)
-      server.watcher.on('delete', watcherDelete)
+      kindWithoutPath.forEach((kind: KindWithoutPath) => {
+        const _watcher = () => watcher(null, kind, watchAndRunConf)
+        server.watcher.on(kind, _watcher)
+      })
     },
   }
 }

--- a/packages/vite-plugin-watch-and-run/src/index.ts
+++ b/packages/vite-plugin-watch-and-run/src/index.ts
@@ -1,115 +1,101 @@
-import { Log, logCyan, logGreen, logMagneta, logRed } from "@kitql/helper";
-import { spawn } from "child_process";
-import micromatch from "micromatch";
+import { Log, logCyan, logGreen, logMagneta, logRed } from '@kitql/helper'
+import { spawn } from 'child_process'
+import micromatch from 'micromatch'
 
 export type Options = {
   /**
    * watch files to trigger the run action (glob format)
    */
-  watch: string;
+  watch: string
   /**
    * Kind of watch that will trigger the run action
    */
-  watchKind?: WatchKind[];
+  watchKind?: WatchKind[]
   /**
    * run command (yarn gen for example!)
    */
-  run: string;
+  run: string
   /**
    * Delay before running the run command (in ms)
    * @default 300 ms
    */
-  delay?: number | null;
+  delay?: number | null
   /**
    * Name to display in the logs as prefix
    */
-  name?: string | null;
-};
+  name?: string | null
+}
 
-export const kindWithPath = [
-  "add",
-  "addDir",
-  "change",
-  "delete",
-  "unlink",
-  "unlinkDir"
-] as const;
-export type KindWithPath = typeof kindWithPath[number];
-export const kindWithoutPath = ["all", "error", "raw", "ready"] as const;
-export type KindWithoutPath = typeof kindWithoutPath[number];
-export type WatchKind = KindWithPath | KindWithoutPath;
+export const kindWithPath = ['add', 'addDir', 'change', 'delete', 'unlink', 'unlinkDir'] as const
+export type KindWithPath = typeof kindWithPath[number]
+export const kindWithoutPath = ['all', 'error', 'raw', 'ready'] as const
+export type KindWithoutPath = typeof kindWithoutPath[number]
+export type WatchKind = KindWithPath | KindWithoutPath
 
 export type StateDetail = {
-  kind: WatchKind[];
-  run: string;
-  delay: number;
-  isRunning: boolean;
-  name?: string | null;
-};
+  kind: WatchKind[]
+  run: string
+  delay: number
+  isRunning: boolean
+  name?: string | null
+}
 
 function checkConf(params: Options[]) {
   if (!Array.isArray(params)) {
-    throw new Error("plugin watchAndRun, `params` needs to be an array.");
+    throw new Error('plugin watchAndRun, `params` needs to be an array.')
   }
 
-  const paramsChecked: Record<string, StateDetail> = {};
+  const paramsChecked: Record<string, StateDetail> = {}
 
   params.forEach(param => {
     if (!param.watch) {
-      throw new Error("plugin watch-and-run, `watch` is missing.");
+      throw new Error('plugin watch-and-run, `watch` is missing.')
     }
     if (!param.run) {
-      throw new Error("plugin watch-and-run, `run` is missing.");
+      throw new Error('plugin watch-and-run, `run` is missing.')
     }
 
     paramsChecked[param.watch] = {
-      kind: param.watchKind ?? ["add", "change", "delete"],
+      kind: param.watchKind ?? ['add', 'change', 'delete'],
       run: param.run,
       delay: param.delay ?? 300,
       isRunning: false,
-      name: param.name
-    };
-  });
+      name: param.name,
+    }
+  })
 
-  return paramsChecked;
+  return paramsChecked
 }
 
 type ShouldRunResult =
   | { shouldRun: true; globToWatch: string; param: StateDetail }
-  | { shouldRun: false; globToWatch: null; param: null };
+  | { shouldRun: false; globToWatch: null; param: null }
 function shouldRun(
   absolutePath: string | null,
   watchKind: WatchKind,
   watchAndRunConf: Record<string, StateDetail>
 ): ShouldRunResult {
   for (const [globToWatch, param] of Object.entries(watchAndRunConf)) {
-    const isWatched = param.kind.includes(watchKind);
-    const isPathMatching =
-      absolutePath && micromatch.isMatch(absolutePath, globToWatch);
-    const isWatchKindWithoutPath = kindWithoutPath.includes(
-      watchKind as KindWithoutPath
-    );
-    if (
-      !param.isRunning &&
-      isWatched &&
-      (isPathMatching || isWatchKindWithoutPath)
-    ) {
+    const isWatched = param.kind.includes(watchKind)
+    const isPathMatching = absolutePath && micromatch.isMatch(absolutePath, globToWatch)
+    const isWatchKindWithoutPath = kindWithoutPath.includes(watchKind as KindWithoutPath)
+    if (!param.isRunning && isWatched && (isPathMatching || isWatchKindWithoutPath)) {
       return {
         shouldRun: true,
         globToWatch,
-        param
-      };
+        param,
+      }
     }
   }
   return {
     shouldRun: false,
     globToWatch: null,
-    param: null
-  };
+    param: null,
+  }
 }
 
 function formatLog(str: string, name?: string) {
-  return `${name ? logMagneta(`[${name}]`) : ""} ${str}`;
+  return `${name ? logMagneta(`[${name}]`) : ''} ${str}`
 }
 
 async function watcher(
@@ -117,75 +103,67 @@ async function watcher(
   watchKind: WatchKind,
   watchAndRunConf: Record<string, StateDetail>
 ) {
-  const shouldRunInfo = shouldRun(absolutePath, watchKind, watchAndRunConf);
+  const shouldRunInfo = shouldRun(absolutePath, watchKind, watchAndRunConf)
   if (shouldRunInfo.shouldRun) {
-    watchAndRunConf[shouldRunInfo.globToWatch].isRunning = true;
+    watchAndRunConf[shouldRunInfo.globToWatch].isRunning = true
 
     log.info(
-      `${logGreen("✔")} Thx to ${logGreen(shouldRunInfo.globToWatch)}, ` +
-        `triggered by ${logCyan(watchKind)} ${absolutePath &&
-          logGreen(absolutePath)}, ` +
-        `we will wait ${logCyan(
-          shouldRunInfo.param.delay + "ms"
-        )} and run ${logGreen(shouldRunInfo.param.run)}.`
-    );
+      `${logGreen('✔')} Thx to ${logGreen(shouldRunInfo.globToWatch)}, ` +
+        `triggered by ${logCyan(watchKind)} ${absolutePath && logGreen(absolutePath)}, ` +
+        `we will wait ${logCyan(shouldRunInfo.param.delay + 'ms')} and run ${logGreen(shouldRunInfo.param.run)}.`
+    )
 
     // Run after a delay
     setTimeout(() => {
-      const child = spawn(shouldRunInfo.param.run, [], { shell: true });
+      const child = spawn(shouldRunInfo.param.run, [], { shell: true })
 
       //spit stdout to screen
-      child.stdout.on("data", data => {
-        process.stdout.write(
-          formatLog(data.toString(), shouldRunInfo.param.name ?? "")
-        );
-      });
+      child.stdout.on('data', data => {
+        process.stdout.write(formatLog(data.toString(), shouldRunInfo.param.name ?? ''))
+      })
 
       //spit stderr to screen
-      child.stderr.on("data", data => {
-        process.stdout.write(
-          formatLog(data.toString(), shouldRunInfo.param.name ?? "")
-        );
-      });
+      child.stderr.on('data', data => {
+        process.stdout.write(formatLog(data.toString(), shouldRunInfo.param.name ?? ''))
+      })
 
-      child.on("close", code => {
+      child.on('close', code => {
         if (code === 0) {
-          log.info(`${logGreen("✔")} finished ${logGreen("successfully")}`);
+          log.info(`${logGreen('✔')} finished ${logGreen('successfully')}`)
         } else {
-          log.error(`finished with some ${logRed("errors")}`);
+          log.error(`finished with some ${logRed('errors')}`)
         }
-        shouldRunInfo.param.isRunning = false;
-      });
+        shouldRunInfo.param.isRunning = false
+      })
 
-      return;
-    }, shouldRunInfo.param.delay);
+      return
+    }, shouldRunInfo.param.delay)
   }
 
-  return;
+  return
 }
 
-const log = new Log("KitQL vite-plugin-watch-and-run");
+const log = new Log('KitQL vite-plugin-watch-and-run')
 
 export default function watchAndRun(params: Options[]) {
   // check params, throw Errors if not valid and return a new object representing the state of the plugin
-  const watchAndRunConf = checkConf(params);
+  const watchAndRunConf = checkConf(params)
 
   return {
-    name: "watch-and-run",
+    name: 'watch-and-run',
 
     watchAndRunConf,
 
     configureServer(server) {
       kindWithPath.forEach((kind: KindWithPath) => {
-        const _watcher = async (absolutePath: string) =>
-          watcher(absolutePath, kind, watchAndRunConf);
-        server.watcher.on(kind, _watcher);
-      });
+        const _watcher = async (absolutePath: string) => watcher(absolutePath, kind, watchAndRunConf)
+        server.watcher.on(kind, _watcher)
+      })
 
       kindWithoutPath.forEach((kind: KindWithoutPath) => {
-        const _watcher = () => watcher(null, kind, watchAndRunConf);
-        server.watcher.on(kind, _watcher);
-      });
-    }
-  };
+        const _watcher = () => watcher(null, kind, watchAndRunConf)
+        server.watcher.on(kind, _watcher)
+      })
+    },
+  }
 }

--- a/packages/vite-plugin-watch-and-run/src/index.ts
+++ b/packages/vite-plugin-watch-and-run/src/index.ts
@@ -55,6 +55,11 @@ function checkConf(params: Options[]) {
       throw new Error('plugin watch-and-run, `run` is missing.')
     }
 
+    // @ts-ignore (because the config is in a js file, and people maybe didn't update their config.)
+    if (param.watchKind === 'ADD' || param.watchKind === 'CHANGE' || param.watchKind === 'DELETE') {
+      throw new Error('BREAKING: ADD, CHANGE, DELETE were renamed add, change, delete. Please update your config.')
+    }
+
     paramsChecked[param.watch] = {
       kind: param.watchKind ?? ['add', 'change', 'delete'],
       run: param.run,

--- a/packages/vite-plugin-watch-and-run/test/plugins.checkConf.spec.ts
+++ b/packages/vite-plugin-watch-and-run/test/plugins.checkConf.spec.ts
@@ -1,124 +1,90 @@
-import watchAndRun, {
-  KindWithoutPath,
-  kindWithoutPath,
-  kindWithPath
-} from "../src";
-import { describe, expect, it, vi } from "vitest";
+import watchAndRun, { KindWithoutPath, kindWithoutPath, kindWithPath } from '../src'
+import { describe, expect, it, vi } from 'vitest'
 
-describe("vite-plugin-watch-and-run", () => {
-  it("Should throw an error as no config is sent", async () => {
+describe('vite-plugin-watch-and-run', () => {
+  it('Should throw an error as no config is sent', async () => {
     const t = () => {
-      watchAndRun(null as any);
-    };
-    expect(t).toThrowErrorMatchingInlineSnapshot(
-      '"plugin watchAndRun, `params` needs to be an array."'
-    );
-  });
+      watchAndRun(null as any)
+    }
+    expect(t).toThrowErrorMatchingInlineSnapshot('"plugin watchAndRun, `params` needs to be an array."')
+  })
 
-  it("Should throw an error as no watch", async () => {
+  it('Should throw an error as no watch', async () => {
     const t = () => {
-      watchAndRun([{} as any]);
-    };
-    expect(t).toThrowErrorMatchingInlineSnapshot(
-      '"plugin watch-and-run, `watch` is missing."'
-    );
-  });
+      watchAndRun([{} as any])
+    }
+    expect(t).toThrowErrorMatchingInlineSnapshot('"plugin watch-and-run, `watch` is missing."')
+  })
 
-  it("Should throw an error as no run", async () => {
+  it('Should throw an error as no run', async () => {
     const t = () => {
-      watchAndRun([{ watch: "hello!" } as any]);
-    };
-    expect(t).toThrowErrorMatchingInlineSnapshot(
-      '"plugin watch-and-run, `run` is missing."'
-    );
-  });
+      watchAndRun([{ watch: 'hello!' } as any])
+    }
+    expect(t).toThrowErrorMatchingInlineSnapshot('"plugin watch-and-run, `run` is missing."')
+  })
 
-  it("Should have a valid conf, with default delay:300", async () => {
-    const watch = "**/*.(gql|graphql)";
-    const plugin = watchAndRun([{ watch, run: "yarn gen" }]);
+  it('Should have a valid conf, with default delay:300', async () => {
+    const watch = '**/*.(gql|graphql)'
+    const plugin = watchAndRun([{ watch, run: 'yarn gen' }])
+
+    expect(plugin.watchAndRunConf).to.have.property(watch).to.have.property('delay', 300)
+  })
+
+  it('Should have a valid conf, with delay 0', async () => {
+    const watch = '**/*.(gql|graphql)'
+    const plugin = watchAndRun([{ watch, run: 'yarn gen', delay: 0 }])
+
+    expect(plugin.watchAndRunConf).to.have.property(watch).to.have.property('delay', 0)
+  })
+
+  it('Should have a valid conf, with default watchKind:add / change / delete', async () => {
+    const watch = '**/*.(gql|graphql)'
+    const plugin = watchAndRun([{ watch, run: 'yarn gen' }])
 
     expect(plugin.watchAndRunConf)
       .to.have.property(watch)
-      .to.have.property("delay", 300);
-  });
+      .to.have.property('kind')
+      .to.have.all.members(['add', 'change', 'delete'])
+  })
 
-  it("Should have a valid conf, with delay 0", async () => {
-    const watch = "**/*.(gql|graphql)";
-    const plugin = watchAndRun([{ watch, run: "yarn gen", delay: 0 }]);
-
-    expect(plugin.watchAndRunConf)
-      .to.have.property(watch)
-      .to.have.property("delay", 0);
-  });
-
-  it("Should have a valid conf, with default watchKind:add / change / delete", async () => {
-    const watch = "**/*.(gql|graphql)";
-    const plugin = watchAndRun([{ watch, run: "yarn gen" }]);
-
-    expect(plugin.watchAndRunConf)
-      .to.have.property(watch)
-      .to.have.property("kind")
-      .to.have.all.members(["add", "change", "delete"]);
-  });
-
-  it("Should run on ready state too", async () => {
-    const watch = "**/*.(gql|graphql)";
+  it('Should run on ready state too', async () => {
+    const watch = '**/*.(gql|graphql)'
     const plugin = watchAndRun([
       {
         watch,
-        run: "yarn gen",
-        watchKind: ["add", "change", "delete", "ready"]
-      }
-    ]);
+        run: 'yarn gen',
+        watchKind: ['add', 'change', 'delete', 'ready'],
+      },
+    ])
 
     expect(plugin.watchAndRunConf)
       .to.have.property(watch)
-      .to.have.property("kind")
-      .to.have.all.members(["add", "change", "delete", "ready"]);
-  });
+      .to.have.property('kind')
+      .to.have.all.members(['add', 'change', 'delete', 'ready'])
+  })
 
-  it("Should register all watchers", async () => {
-    const watch = "**/*.(gql|graphql)";
-    const plugin = watchAndRun([{ watch, run: "yarn gen" }]);
+  it('Should register all watchers', async () => {
+    const watch = '**/*.(gql|graphql)'
+    const plugin = watchAndRun([{ watch, run: 'yarn gen' }])
 
     const server = {
       watcher: {
-        on: vi.fn()
+        on: vi.fn(),
+      },
+    }
+    const spy = vi.spyOn(server.watcher, 'on').mockImplementation((type: 'add' | 'change' | 'delete', callback) => {
+      if (kindWithPath.includes(type) || kindWithoutPath.includes(type as KindWithoutPath)) {
+        // eslint-disable-next-line unicorn/no-lonely-if
+        if (typeof callback === 'function') return 'registered'
       }
-    };
-    const spy = vi
-      .spyOn(server.watcher, "on")
-      .mockImplementation((type: "add" | "change" | "delete", callback) => {
-        if (
-          kindWithPath.includes(type) ||
-          kindWithoutPath.includes(type as KindWithoutPath)
-        ) {
-          // eslint-disable-next-line unicorn/no-lonely-if
-          if (typeof callback === "function") return "registered";
-        }
-        return "error";
-      });
-    plugin.configureServer(server);
-    expect(spy).toHaveBeenCalledTimes(10);
-    const operations = [
-      "add",
-      "addDir",
-      "change",
-      "delete",
-      "unlink",
-      "unlinkDir",
-      /**/ "all",
-      "error",
-      "raw",
-      "ready"
-    ];
+      return 'error'
+    })
+    plugin.configureServer(server)
+    expect(spy).toHaveBeenCalledTimes(10)
+    const operations = ['add', 'addDir', 'change', 'delete', 'unlink', 'unlinkDir', 'all', 'error', 'raw', 'ready']
     spy.mock.calls.forEach((call, index) => {
-      expect(spy).toHaveBeenNthCalledWith(
-        index + 1,
-        operations[index],
-        call[1]
-      );
-      expect(spy).toHaveNthReturnedWith(index + 1, "registered");
-    });
-  });
-});
+      expect(spy).toHaveBeenNthCalledWith(index + 1, operations[index], call[1])
+      expect(spy).toHaveNthReturnedWith(index + 1, 'registered')
+    })
+  })
+})

--- a/packages/vite-plugin-watch-and-run/test/plugins.checkConf.spec.ts
+++ b/packages/vite-plugin-watch-and-run/test/plugins.checkConf.spec.ts
@@ -1,10 +1,10 @@
-import watchAndRun from '../src'
+import watchAndRun, { KindWithoutPath, kindWithoutPath, kindWithPath } from '../src'
 import { describe, expect, it, vi } from 'vitest'
 
 describe('vite-plugin-watch-and-run', () => {
   it('Should throw an error as no config is sent', async () => {
     const t = () => {
-      watchAndRun(null)
+      watchAndRun(null as any)
     }
     expect(t).toThrowErrorMatchingInlineSnapshot('"plugin watchAndRun, `params` needs to be an array."')
   })
@@ -37,14 +37,24 @@ describe('vite-plugin-watch-and-run', () => {
     expect(plugin.watchAndRunConf).to.have.property(watch).to.have.property('delay', 0)
   })
 
-  it('Should have a valid conf, with default watchKind:ADD / CHANGE / DELETE', async () => {
+  it('Should have a valid conf, with default watchKind:add / change / delete', async () => {
     const watch = '**/*.(gql|graphql)'
     const plugin = watchAndRun([{ watch, run: 'yarn gen' }])
 
     expect(plugin.watchAndRunConf)
       .to.have.property(watch)
       .to.have.property('kind')
-      .to.have.all.members(['ADD', 'CHANGE', 'DELETE'])
+      .to.have.all.members(['add', 'change', 'delete'])
+  })
+
+  it('Should run on ready state too', async () => {
+    const watch = '**/*.(gql|graphql)'
+    const plugin = watchAndRun([{ watch, run: 'yarn gen', watchKind: ['add', 'change', 'delete', 'ready'] }])
+    
+    expect(plugin.watchAndRunConf)
+      .to.have.property(watch)
+      .to.have.property('kind')
+      .to.have.all.members(['add', 'change', 'delete', 'ready'])
   })
 
   it('Should register all watchers', async () => {
@@ -57,15 +67,15 @@ describe('vite-plugin-watch-and-run', () => {
       },
     }
     const spy = vi.spyOn(server.watcher, 'on').mockImplementation((type: 'add' | 'change' | 'delete', callback) => {
-      if (type === 'add' || type === 'change' || type === 'delete') {
+      if (kindWithPath.includes(type) || kindWithoutPath.includes(type as KindWithoutPath)) {
         // eslint-disable-next-line unicorn/no-lonely-if
         if (typeof callback === 'function') return 'registered'
       }
       return 'error'
     })
     plugin.configureServer(server)
-    expect(spy).toHaveBeenCalledTimes(3)
-    const operations = ['add', 'change', 'delete']
+    expect(spy).toHaveBeenCalledTimes(10)
+    const operations = ['add', 'addDir', 'change', 'delete', 'unlink', 'unlinkDir', /**/ 'all', 'error', 'raw', 'ready']
     spy.mock.calls.forEach((call, index) => {
       expect(spy).toHaveBeenNthCalledWith(index + 1, operations[index], call[1])
       expect(spy).toHaveNthReturnedWith(index + 1, 'registered')

--- a/packages/vite-plugin-watch-and-run/test/plugins.checkConf.spec.ts
+++ b/packages/vite-plugin-watch-and-run/test/plugins.checkConf.spec.ts
@@ -1,84 +1,124 @@
-import watchAndRun, { KindWithoutPath, kindWithoutPath, kindWithPath } from '../src'
-import { describe, expect, it, vi } from 'vitest'
+import watchAndRun, {
+  KindWithoutPath,
+  kindWithoutPath,
+  kindWithPath
+} from "../src";
+import { describe, expect, it, vi } from "vitest";
 
-describe('vite-plugin-watch-and-run', () => {
-  it('Should throw an error as no config is sent', async () => {
+describe("vite-plugin-watch-and-run", () => {
+  it("Should throw an error as no config is sent", async () => {
     const t = () => {
-      watchAndRun(null as any)
-    }
-    expect(t).toThrowErrorMatchingInlineSnapshot('"plugin watchAndRun, `params` needs to be an array."')
-  })
+      watchAndRun(null as any);
+    };
+    expect(t).toThrowErrorMatchingInlineSnapshot(
+      '"plugin watchAndRun, `params` needs to be an array."'
+    );
+  });
 
-  it('Should throw an error as no watch', async () => {
+  it("Should throw an error as no watch", async () => {
     const t = () => {
-      watchAndRun([{} as any])
-    }
-    expect(t).toThrowErrorMatchingInlineSnapshot('"plugin watch-and-run, `watch` is missing."')
-  })
+      watchAndRun([{} as any]);
+    };
+    expect(t).toThrowErrorMatchingInlineSnapshot(
+      '"plugin watch-and-run, `watch` is missing."'
+    );
+  });
 
-  it('Should throw an error as no run', async () => {
+  it("Should throw an error as no run", async () => {
     const t = () => {
-      watchAndRun([{ watch: 'hello!' } as any])
-    }
-    expect(t).toThrowErrorMatchingInlineSnapshot('"plugin watch-and-run, `run` is missing."')
-  })
+      watchAndRun([{ watch: "hello!" } as any]);
+    };
+    expect(t).toThrowErrorMatchingInlineSnapshot(
+      '"plugin watch-and-run, `run` is missing."'
+    );
+  });
 
-  it('Should have a valid conf, with default delay:300', async () => {
-    const watch = '**/*.(gql|graphql)'
-    const plugin = watchAndRun([{ watch, run: 'yarn gen' }])
-
-    expect(plugin.watchAndRunConf).to.have.property(watch).to.have.property('delay', 300)
-  })
-
-  it('Should have a valid conf, with delay 0', async () => {
-    const watch = '**/*.(gql|graphql)'
-    const plugin = watchAndRun([{ watch, run: 'yarn gen', delay: 0 }])
-
-    expect(plugin.watchAndRunConf).to.have.property(watch).to.have.property('delay', 0)
-  })
-
-  it('Should have a valid conf, with default watchKind:add / change / delete', async () => {
-    const watch = '**/*.(gql|graphql)'
-    const plugin = watchAndRun([{ watch, run: 'yarn gen' }])
+  it("Should have a valid conf, with default delay:300", async () => {
+    const watch = "**/*.(gql|graphql)";
+    const plugin = watchAndRun([{ watch, run: "yarn gen" }]);
 
     expect(plugin.watchAndRunConf)
       .to.have.property(watch)
-      .to.have.property('kind')
-      .to.have.all.members(['add', 'change', 'delete'])
-  })
+      .to.have.property("delay", 300);
+  });
 
-  it('Should run on ready state too', async () => {
-    const watch = '**/*.(gql|graphql)'
-    const plugin = watchAndRun([{ watch, run: 'yarn gen', watchKind: ['add', 'change', 'delete', 'ready'] }])
-    
+  it("Should have a valid conf, with delay 0", async () => {
+    const watch = "**/*.(gql|graphql)";
+    const plugin = watchAndRun([{ watch, run: "yarn gen", delay: 0 }]);
+
     expect(plugin.watchAndRunConf)
       .to.have.property(watch)
-      .to.have.property('kind')
-      .to.have.all.members(['add', 'change', 'delete', 'ready'])
-  })
+      .to.have.property("delay", 0);
+  });
 
-  it('Should register all watchers', async () => {
-    const watch = '**/*.(gql|graphql)'
-    const plugin = watchAndRun([{ watch, run: 'yarn gen' }])
+  it("Should have a valid conf, with default watchKind:add / change / delete", async () => {
+    const watch = "**/*.(gql|graphql)";
+    const plugin = watchAndRun([{ watch, run: "yarn gen" }]);
+
+    expect(plugin.watchAndRunConf)
+      .to.have.property(watch)
+      .to.have.property("kind")
+      .to.have.all.members(["add", "change", "delete"]);
+  });
+
+  it("Should run on ready state too", async () => {
+    const watch = "**/*.(gql|graphql)";
+    const plugin = watchAndRun([
+      {
+        watch,
+        run: "yarn gen",
+        watchKind: ["add", "change", "delete", "ready"]
+      }
+    ]);
+
+    expect(plugin.watchAndRunConf)
+      .to.have.property(watch)
+      .to.have.property("kind")
+      .to.have.all.members(["add", "change", "delete", "ready"]);
+  });
+
+  it("Should register all watchers", async () => {
+    const watch = "**/*.(gql|graphql)";
+    const plugin = watchAndRun([{ watch, run: "yarn gen" }]);
 
     const server = {
       watcher: {
-        on: vi.fn(),
-      },
-    }
-    const spy = vi.spyOn(server.watcher, 'on').mockImplementation((type: 'add' | 'change' | 'delete', callback) => {
-      if (kindWithPath.includes(type) || kindWithoutPath.includes(type as KindWithoutPath)) {
-        // eslint-disable-next-line unicorn/no-lonely-if
-        if (typeof callback === 'function') return 'registered'
+        on: vi.fn()
       }
-      return 'error'
-    })
-    plugin.configureServer(server)
-    expect(spy).toHaveBeenCalledTimes(10)
-    const operations = ['add', 'addDir', 'change', 'delete', 'unlink', 'unlinkDir', /**/ 'all', 'error', 'raw', 'ready']
+    };
+    const spy = vi
+      .spyOn(server.watcher, "on")
+      .mockImplementation((type: "add" | "change" | "delete", callback) => {
+        if (
+          kindWithPath.includes(type) ||
+          kindWithoutPath.includes(type as KindWithoutPath)
+        ) {
+          // eslint-disable-next-line unicorn/no-lonely-if
+          if (typeof callback === "function") return "registered";
+        }
+        return "error";
+      });
+    plugin.configureServer(server);
+    expect(spy).toHaveBeenCalledTimes(10);
+    const operations = [
+      "add",
+      "addDir",
+      "change",
+      "delete",
+      "unlink",
+      "unlinkDir",
+      /**/ "all",
+      "error",
+      "raw",
+      "ready"
+    ];
     spy.mock.calls.forEach((call, index) => {
-      expect(spy).toHaveBeenNthCalledWith(index + 1, operations[index], call[1])
-      expect(spy).toHaveNthReturnedWith(index + 1, 'registered')
-    })
-  })
-})
+      expect(spy).toHaveBeenNthCalledWith(
+        index + 1,
+        operations[index],
+        call[1]
+      );
+      expect(spy).toHaveNthReturnedWith(index + 1, "registered");
+    });
+  });
+});


### PR DESCRIPTION
Current implementation only watches 3 hooks: add, change and delete.

I needed to use the "ready" hook too in my app to run the command apppearing as soon as the vite server started. I just added the other hooks in the process: "addDir", "all", "error", "raw", "ready", "unlink", "unlinkDir".