### PR TITLE
IMPROVE: reuse existing function

### DIFF
--- a/packages/helper/src/stry.ts
+++ b/packages/helper/src/stry.ts
@@ -22,9 +22,5 @@ export function stry(
   if (obj === null) {
     return null
   }
-  if (obj === undefined) {
-    return undefined
-  }
-  stringify.configure({ deterministic: true })
   return stringify(obj, replacer, space)
 }


### PR DESCRIPTION
The stringify function may be reused instead of being recreated on each call and it is deterministic by default (the returned function is actually not used currently). Since `JSON.stringify(undefined)` also returns `undefined`, that condition is also removed.