### PR TITLE
Update path for types 

### DIFF
--- a/packages/vite-plugin-watch-and-run/package.json
+++ b/packages/vite-plugin-watch-and-run/package.json
@@ -54,8 +54,8 @@
     "!dist/**/*.test.*",
     "!dist/**/*.spec.*"
   ],
-  "svelte": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "svelte": "./esm/index.js",
+  "types": "./esm/index.d.ts",
   "exports": {
     ".": {
       "require": "./cjs/index.js",


### PR DESCRIPTION
Changed path for typings, from the non-existent 'dist' folder to 'esm', where index.d.ts lives.

This would fix the Typescript issue:

![error](https://github.com/jycouet/kitql/assets/6638917/c71a84eb-3dc6-49de-8306-c81f32452dd3)

regarding it not able to find the type definitions (when using CJS)