### PR TITLE
Generate routes during build

### DIFF
--- a/.changeset/short-vans-camp.md
+++ b/.changeset/short-vans-camp.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-kit-routes': minor
+---
+
+also generate routes during build

--- a/packages/vite-plugin-kit-routes/src/lib/plugin.ts
+++ b/packages/vite-plugin-kit-routes/src/lib/plugin.ts
@@ -1067,7 +1067,7 @@ export function kitRoutes<T extends ExtendTypes = ExtendTypes>(options?: Options
     // Run the thing at startup
     {
       name: 'kit-routes',
-      configureServer() {
+      buildStart() {
         run(true, options)
       },
     },

--- a/packages/vite-plugin-kit-routes/src/lib/plugin.ts
+++ b/packages/vite-plugin-kit-routes/src/lib/plugin.ts
@@ -1,6 +1,6 @@
 import { cyan, gray, green, italic, Log, red, stry0, yellow } from '@kitql/helpers'
 import { getFilesUnder, read, write, relative, dirname } from '@kitql/internals'
-import { spawn } from 'child_process'
+import { spawnSync } from 'child_process'
 import type { Plugin } from 'vite'
 import { watchAndRun } from 'vite-plugin-watch-and-run'
 
@@ -942,28 +942,26 @@ ${objTypes
       }
 
       // do the stuff
-      const child = spawn(options.post_update_run, { shell: true })
+      const child = spawnSync(options.post_update_run, { shell: true })
 
       // report things
       if (shouldLog('post_update_run', options)) {
-        child.stdout.on('data', data => {
-          if (data.toString()) {
-            log.info(data.toString())
-          }
-        })
+        const stdout = child.stdout.toString()
+        if (stdout) {
+          log.info(stdout)
+        }
       }
 
       // report errors
       if (shouldLog('errors', options)) {
-        child.stderr.on('data', data => {
-          log.error(data.toString())
-        })
+        const stderr = child.stderr.toString()
+        if (stderr) {
+          log.error(stderr)
+        }
       }
 
       if (shouldLog('update', options)) {
-        child.on('close', () => {
-          theEnd(atStart, result, objTypes, options)
-        })
+        theEnd(atStart, result, objTypes, options)
       }
     } else {
       theEnd(atStart, result, objTypes, options)

--- a/packages/vite-plugin-kit-routes/src/lib/plugins.spec.ts
+++ b/packages/vite-plugin-kit-routes/src/lib/plugins.spec.ts
@@ -460,7 +460,7 @@ describe('run()', async () => {
   for (let i = 0; i < runs.length; i++) {
     const toRun = runs[i]
     it(`run ${toRun.pathFile}`, async () => {
-      const ret = run(false, {
+      const ret = await run(false, {
         format: toRun.format,
         generated_file_path: getPathROUTES(toRun.pathFile),
         ...toRun.extra,
@@ -474,7 +474,7 @@ describe('run()', async () => {
     const toRun = getToRunShortened(runs[i])
 
     it(`run ${toRun.pathFile}`, async () => {
-      const ret = run(false, {
+      const ret = await run(false, {
         format: toRun.format,
         generated_file_path: getPathROUTES(toRun.pathFile),
         ...toRun.extra,
@@ -769,9 +769,9 @@ describe('run()', async () => {
     })
   }
 
-  it('post_update_run', () => {
+  it('post_update_run', async () => {
     const generated_file_path = 'src/test/ROUTES_post-update.ts'
-    run(false, {
+    await run(false, {
       generated_file_path,
       post_update_run: 'echo done',
     })
@@ -779,9 +779,9 @@ describe('run()', async () => {
     expect(true).toBe(true)
   })
 
-  it('with path base', () => {
+  it('with path base', async () => {
     const generated_file_path = 'src/test/ROUTES_base.ts'
-    run(false, {
+    await run(false, {
       generated_file_path,
       path_base: true,
     })


### PR DESCRIPTION
Rollup's `buildStart` gets called by `pnpm dev` and `pnpm build`, so it can be used to generate the routes file during build. And this allows to `.gitignore` it :tada: 

I needed to call the post update command synchronously but I don't think this should be a problem?