### PR TITLE
allow overriding param matcher types

### DIFF
--- a/.changeset/pink-ties-press.md
+++ b/.changeset/pink-ties-press.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-kit-routes': minor
+---
+
+Allow overriding param matcher types

--- a/packages/vite-plugin-kit-routes/src/lib/ROUTES.ts
+++ b/packages/vite-plugin-kit-routes/src/lib/ROUTES.ts
@@ -34,7 +34,7 @@ const PAGES = {
     return `${params?.lang ? `/${params?.lang}` : ''}/main`
   },
   '/match/[id=ab]': (params: {
-    id: Parameters<typeof import('../params/ab.ts').match>[0]
+    id: ParamMatcherParam<typeof import('../params/ab.ts').match>
     lang?: 'fr' | 'en' | 'hu' | 'at' | string
   }) => {
     return `${params?.lang ? `/${params?.lang}` : ''}/match/${params.id}`
@@ -268,6 +268,9 @@ export function route<T extends keyof AllTypes>(key: T, ...params: any[]): strin
     return AllObjs[key] as string
   }
 }
+
+type ParamMatcherParam<T extends (...args: any) => any> = ExtractParam<Parameters<T>[0]>
+type ExtractParam<T> = T extends `${number}` ? number : T
 
 /**
  * Add this type as a generic of the vite plugin `kitRoutes<KIT_ROUTES>`.

--- a/packages/vite-plugin-kit-routes/src/lib/plugins.spec.ts
+++ b/packages/vite-plugin-kit-routes/src/lib/plugins.spec.ts
@@ -95,7 +95,7 @@ describe('vite-plugin-kit-routes', () => {
           "matcher": "ab",
           "name": "tmp",
           "optional": false,
-          "type": "Parameters<typeof import('../params/ab.ts').match>[0]",
+          "type": "ParamMatcherParam<typeof import('../params/ab.ts').match>",
         },
       ]
     `)
@@ -115,7 +115,7 @@ describe('vite-plugin-kit-routes', () => {
           "matcher": "ab",
           "name": "tmp",
           "optional": false,
-          "type": "Parameters<typeof import('../../my/custom/path/ab.ts').match>[0]",
+          "type": "ParamMatcherParam<typeof import('../../my/custom/path/ab.ts').match>",
         },
       ]
     `)
@@ -313,6 +313,7 @@ describe('run()', async () => {
     override_params: {
       lang: { type: "'fr' | 'en' | 'hu' | 'at' | string" },
     },
+    override_matcher_params: ['number'],
   }
 
   const commonConfig_variables: Options<KIT_ROUTES_ObjectSymbol> = {
@@ -774,6 +775,7 @@ describe('run()', async () => {
     await run(false, {
       generated_file_path,
       post_update_run: 'echo done',
+      override_matcher_params: ['number'],
     })
 
     expect(true).toBe(true)
@@ -784,6 +786,7 @@ describe('run()', async () => {
     await run(false, {
       generated_file_path,
       path_base: true,
+      override_matcher_params: ['number'],
     })
 
     expect(read(generated_file_path)?.includes("import { base } from '$app/paths'")).toBe(true)

--- a/packages/vite-plugin-kit-routes/src/params/int.ts
+++ b/packages/vite-plugin-kit-routes/src/params/int.ts
@@ -1,5 +1,3 @@
-import type { ParamMatcher } from '@sveltejs/kit'
-
-export const match: ParamMatcher = param => {
+export const match = (param: `${number}`) => {
   return /^\d+$/.test(param)
 }

--- a/packages/vite-plugin-kit-routes/src/test/ROUTES_base.ts
+++ b/packages/vite-plugin-kit-routes/src/test/ROUTES_base.ts
@@ -29,10 +29,10 @@ const PAGES = {
   "/main": (params?: { lang?: (string | number) }) => {
     return `${base}${params?.lang ? `/${params?.lang}`: ''}/main`
   },
-  "/match/[id=ab]": (params: { id: (Parameters<typeof import('../params/ab.ts').match>[0]), lang?: (string | number) }) => {
+  "/match/[id=ab]": (params: { id: (ParamMatcherParam<typeof import('../params/ab.ts').match>), lang?: (string | number) }) => {
     return `${base}${params?.lang ? `/${params?.lang}`: ''}/match/${params.id}`
   },
-  "/match/[id=int]": (params: { id: (Parameters<typeof import('../params/int.ts').match>[0]), lang?: (string | number) }) => {
+  "/match/[id=int]": (params: { id: (ParamMatcherParam<typeof import('../params/int.ts').match>), lang?: (string | number) }) => {
     return `${base}${params?.lang ? `/${params?.lang}`: ''}/match/${params.id}`
   },
   "/site": (params?: { lang?: (string | number) }) => {
@@ -191,6 +191,9 @@ export function route<T extends keyof AllTypes>(key: T, ...params: any[]): strin
     return AllObjs[key] as string
   }
 }
+
+type ParamMatcherParam<T extends (...args: any) => any> = ExtractParam<Parameters<T>[0]>;
+type ExtractParam<T> = T extends `${number}` ? number : T;
 
 /**
 * Add this type as a generic of the vite plugin `kitRoutes<KIT_ROUTES>`.

--- a/packages/vite-plugin-kit-routes/src/test/ROUTES_format-object-path.ts
+++ b/packages/vite-plugin-kit-routes/src/test/ROUTES_format-object-path.ts
@@ -30,7 +30,7 @@ export const PAGES = {
   "/main": (params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/main`
   },
-  "/match/[id=ab]": (params: { id: (Parameters<typeof import('../params/ab.ts').match>[0]), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
+  "/match/[id=ab]": (params: { id: (ParamMatcherParam<typeof import('../params/ab.ts').match>), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/match/${params.id}`
   },
   "/match/[id=int]": (params: { id: (number), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
@@ -177,6 +177,9 @@ function StringOrUndefined(val: any) {
 
   return String(val)
 }
+
+type ParamMatcherParam<T extends (...args: any) => any> = ExtractParam<Parameters<T>[0]>;
+type ExtractParam<T> = T extends `${number}` ? number : T;
 
 /**
 * Add this type as a generic of the vite plugin `kitRoutes<KIT_ROUTES>`.

--- a/packages/vite-plugin-kit-routes/src/test/ROUTES_format-object-path_shortened.ts
+++ b/packages/vite-plugin-kit-routes/src/test/ROUTES_format-object-path_shortened.ts
@@ -30,7 +30,7 @@ export const PAGES = {
   "/main": (params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/main`
   },
-  "/match/[id=ab]": (id: (Parameters<typeof import('../params/ab.ts').match>[0]), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
+  "/match/[id=ab]": (id: (ParamMatcherParam<typeof import('../params/ab.ts').match>), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/match/${id}`
   },
   "/match/[id=int]": (id: (number), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
@@ -178,6 +178,9 @@ function StringOrUndefined(val: any) {
 
   return String(val)
 }
+
+type ParamMatcherParam<T extends (...args: any) => any> = ExtractParam<Parameters<T>[0]>;
+type ExtractParam<T> = T extends `${number}` ? number : T;
 
 /**
 * Add this type as a generic of the vite plugin `kitRoutes<KIT_ROUTES>`.

--- a/packages/vite-plugin-kit-routes/src/test/ROUTES_format-object-symbol.ts
+++ b/packages/vite-plugin-kit-routes/src/test/ROUTES_format-object-symbol.ts
@@ -30,7 +30,7 @@ export const PAGES = {
   "main": (params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/main`
   },
-  "match_id_ab": (params: { id: (Parameters<typeof import('../params/ab.ts').match>[0]), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
+  "match_id_ab": (params: { id: (ParamMatcherParam<typeof import('../params/ab.ts').match>), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/match/${params.id}`
   },
   "match_id_int": (params: { id: (number), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
@@ -181,6 +181,9 @@ function StringOrUndefined(val: any) {
 
   return String(val)
 }
+
+type ParamMatcherParam<T extends (...args: any) => any> = ExtractParam<Parameters<T>[0]>;
+type ExtractParam<T> = T extends `${number}` ? number : T;
 
 /**
 * Add this type as a generic of the vite plugin `kitRoutes<KIT_ROUTES>`.

--- a/packages/vite-plugin-kit-routes/src/test/ROUTES_format-object-symbol_shortened.ts
+++ b/packages/vite-plugin-kit-routes/src/test/ROUTES_format-object-symbol_shortened.ts
@@ -30,7 +30,7 @@ export const PAGES = {
   "main": (params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/main`
   },
-  "match_id_ab": (id: (Parameters<typeof import('../params/ab.ts').match>[0]), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
+  "match_id_ab": (id: (ParamMatcherParam<typeof import('../params/ab.ts').match>), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/match/${id}`
   },
   "match_id_int": (id: (number), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
@@ -182,6 +182,9 @@ function StringOrUndefined(val: any) {
 
   return String(val)
 }
+
+type ParamMatcherParam<T extends (...args: any) => any> = ExtractParam<Parameters<T>[0]>;
+type ExtractParam<T> = T extends `${number}` ? number : T;
 
 /**
 * Add this type as a generic of the vite plugin `kitRoutes<KIT_ROUTES>`.

--- a/packages/vite-plugin-kit-routes/src/test/ROUTES_format-route-and-object-path.ts
+++ b/packages/vite-plugin-kit-routes/src/test/ROUTES_format-route-and-object-path.ts
@@ -30,7 +30,7 @@ export const PAGES = {
   "/main": (params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/main`
   },
-  "/match/[id=ab]": (params: { id: (Parameters<typeof import('../params/ab.ts').match>[0]), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
+  "/match/[id=ab]": (params: { id: (ParamMatcherParam<typeof import('../params/ab.ts').match>), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/match/${params.id}`
   },
   "/match/[id=int]": (params: { id: (number), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
@@ -204,6 +204,9 @@ export function route<T extends keyof AllTypes>(key: T, ...params: any[]): strin
     return AllObjs[key] as string
   }
 }
+
+type ParamMatcherParam<T extends (...args: any) => any> = ExtractParam<Parameters<T>[0]>;
+type ExtractParam<T> = T extends `${number}` ? number : T;
 
 /**
 * Add this type as a generic of the vite plugin `kitRoutes<KIT_ROUTES>`.

--- a/packages/vite-plugin-kit-routes/src/test/ROUTES_format-route-and-object-path_shortened.ts
+++ b/packages/vite-plugin-kit-routes/src/test/ROUTES_format-route-and-object-path_shortened.ts
@@ -30,7 +30,7 @@ export const PAGES = {
   "/main": (params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/main`
   },
-  "/match/[id=ab]": (id: (Parameters<typeof import('../params/ab.ts').match>[0]), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
+  "/match/[id=ab]": (id: (ParamMatcherParam<typeof import('../params/ab.ts').match>), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/match/${id}`
   },
   "/match/[id=int]": (id: (number), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
@@ -205,6 +205,9 @@ export function route<T extends keyof AllTypes>(key: T, ...params: any[]): strin
     return AllObjs[key] as string
   }
 }
+
+type ParamMatcherParam<T extends (...args: any) => any> = ExtractParam<Parameters<T>[0]>;
+type ExtractParam<T> = T extends `${number}` ? number : T;
 
 /**
 * Add this type as a generic of the vite plugin `kitRoutes<KIT_ROUTES>`.

--- a/packages/vite-plugin-kit-routes/src/test/ROUTES_format-route-and-object-symbol.ts
+++ b/packages/vite-plugin-kit-routes/src/test/ROUTES_format-route-and-object-symbol.ts
@@ -30,7 +30,7 @@ export const PAGES = {
   "main": (params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/main`
   },
-  "match_id_ab": (params: { id: (Parameters<typeof import('../params/ab.ts').match>[0]), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
+  "match_id_ab": (params: { id: (ParamMatcherParam<typeof import('../params/ab.ts').match>), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/match/${params.id}`
   },
   "match_id_int": (params: { id: (number), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
@@ -204,6 +204,9 @@ export function route<T extends keyof AllTypes>(key: T, ...params: any[]): strin
     return AllObjs[key] as string
   }
 }
+
+type ParamMatcherParam<T extends (...args: any) => any> = ExtractParam<Parameters<T>[0]>;
+type ExtractParam<T> = T extends `${number}` ? number : T;
 
 /**
 * Add this type as a generic of the vite plugin `kitRoutes<KIT_ROUTES>`.

--- a/packages/vite-plugin-kit-routes/src/test/ROUTES_format-route-and-object-symbol_shortened.ts
+++ b/packages/vite-plugin-kit-routes/src/test/ROUTES_format-route-and-object-symbol_shortened.ts
@@ -30,7 +30,7 @@ export const PAGES = {
   "main": (params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/main`
   },
-  "match_id_ab": (id: (Parameters<typeof import('../params/ab.ts').match>[0]), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
+  "match_id_ab": (id: (ParamMatcherParam<typeof import('../params/ab.ts').match>), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/match/${id}`
   },
   "match_id_int": (id: (number), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
@@ -205,6 +205,9 @@ export function route<T extends keyof AllTypes>(key: T, ...params: any[]): strin
     return AllObjs[key] as string
   }
 }
+
+type ParamMatcherParam<T extends (...args: any) => any> = ExtractParam<Parameters<T>[0]>;
+type ExtractParam<T> = T extends `${number}` ? number : T;
 
 /**
 * Add this type as a generic of the vite plugin `kitRoutes<KIT_ROUTES>`.

--- a/packages/vite-plugin-kit-routes/src/test/ROUTES_format-route-path.ts
+++ b/packages/vite-plugin-kit-routes/src/test/ROUTES_format-route-path.ts
@@ -30,7 +30,7 @@ const PAGES = {
   "/main": (params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/main`
   },
-  "/match/[id=ab]": (params: { id: (Parameters<typeof import('../params/ab.ts').match>[0]), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
+  "/match/[id=ab]": (params: { id: (ParamMatcherParam<typeof import('../params/ab.ts').match>), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/match/${params.id}`
   },
   "/match/[id=int]": (params: { id: (number), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
@@ -204,6 +204,9 @@ export function route<T extends keyof AllTypes>(key: T, ...params: any[]): strin
     return AllObjs[key] as string
   }
 }
+
+type ParamMatcherParam<T extends (...args: any) => any> = ExtractParam<Parameters<T>[0]>;
+type ExtractParam<T> = T extends `${number}` ? number : T;
 
 /**
 * Add this type as a generic of the vite plugin `kitRoutes<KIT_ROUTES>`.

--- a/packages/vite-plugin-kit-routes/src/test/ROUTES_format-route-path_shortened.ts
+++ b/packages/vite-plugin-kit-routes/src/test/ROUTES_format-route-path_shortened.ts
@@ -30,7 +30,7 @@ const PAGES = {
   "/main": (params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/main`
   },
-  "/match/[id=ab]": (id: (Parameters<typeof import('../params/ab.ts').match>[0]), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
+  "/match/[id=ab]": (id: (ParamMatcherParam<typeof import('../params/ab.ts').match>), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/match/${id}`
   },
   "/match/[id=int]": (id: (number), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
@@ -205,6 +205,9 @@ export function route<T extends keyof AllTypes>(key: T, ...params: any[]): strin
     return AllObjs[key] as string
   }
 }
+
+type ParamMatcherParam<T extends (...args: any) => any> = ExtractParam<Parameters<T>[0]>;
+type ExtractParam<T> = T extends `${number}` ? number : T;
 
 /**
 * Add this type as a generic of the vite plugin `kitRoutes<KIT_ROUTES>`.

--- a/packages/vite-plugin-kit-routes/src/test/ROUTES_format-route-symbol.ts
+++ b/packages/vite-plugin-kit-routes/src/test/ROUTES_format-route-symbol.ts
@@ -30,7 +30,7 @@ const PAGES = {
   "main": (params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/main`
   },
-  "match_id_ab": (params: { id: (Parameters<typeof import('../params/ab.ts').match>[0]), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
+  "match_id_ab": (params: { id: (ParamMatcherParam<typeof import('../params/ab.ts').match>), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/match/${params.id}`
   },
   "match_id_int": (params: { id: (number), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
@@ -204,6 +204,9 @@ export function route<T extends keyof AllTypes>(key: T, ...params: any[]): strin
     return AllObjs[key] as string
   }
 }
+
+type ParamMatcherParam<T extends (...args: any) => any> = ExtractParam<Parameters<T>[0]>;
+type ExtractParam<T> = T extends `${number}` ? number : T;
 
 /**
 * Add this type as a generic of the vite plugin `kitRoutes<KIT_ROUTES>`.

--- a/packages/vite-plugin-kit-routes/src/test/ROUTES_format-route-symbol_shortened.ts
+++ b/packages/vite-plugin-kit-routes/src/test/ROUTES_format-route-symbol_shortened.ts
@@ -30,7 +30,7 @@ const PAGES = {
   "main": (params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/main`
   },
-  "match_id_ab": (id: (Parameters<typeof import('../params/ab.ts').match>[0]), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
+  "match_id_ab": (id: (ParamMatcherParam<typeof import('../params/ab.ts').match>), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/match/${id}`
   },
   "match_id_int": (id: (number), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
@@ -205,6 +205,9 @@ export function route<T extends keyof AllTypes>(key: T, ...params: any[]): strin
     return AllObjs[key] as string
   }
 }
+
+type ParamMatcherParam<T extends (...args: any) => any> = ExtractParam<Parameters<T>[0]>;
+type ExtractParam<T> = T extends `${number}` ? number : T;
 
 /**
 * Add this type as a generic of the vite plugin `kitRoutes<KIT_ROUTES>`.

--- a/packages/vite-plugin-kit-routes/src/test/ROUTES_format-variables.ts
+++ b/packages/vite-plugin-kit-routes/src/test/ROUTES_format-variables.ts
@@ -29,7 +29,7 @@ export const PAGE_gp_two = (params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | strin
 export const PAGE_main = (params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
   return `${params?.lang ? `/${params?.lang}`: ''}/main`
 }
-export const PAGE_match_id_ab = (params: { id: (Parameters<typeof import('../params/ab.ts').match>[0]), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
+export const PAGE_match_id_ab = (params: { id: (ParamMatcherParam<typeof import('../params/ab.ts').match>), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
   return `${params?.lang ? `/${params?.lang}`: ''}/match/${params.id}`
 }
 export const PAGE_match_id_int = (params: { id: (number), lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
@@ -173,6 +173,9 @@ function StringOrUndefined(val: any) {
 
   return String(val)
 }
+
+type ParamMatcherParam<T extends (...args: any) => any> = ExtractParam<Parameters<T>[0]>;
+type ExtractParam<T> = T extends `${number}` ? number : T;
 
 /**
 * Add this type as a generic of the vite plugin `kitRoutes<KIT_ROUTES>`.

--- a/packages/vite-plugin-kit-routes/src/test/ROUTES_format-variables_shortened.ts
+++ b/packages/vite-plugin-kit-routes/src/test/ROUTES_format-variables_shortened.ts
@@ -29,7 +29,7 @@ export const PAGE_gp_two = (params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | strin
 export const PAGE_main = (params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
   return `${params?.lang ? `/${params?.lang}`: ''}/main`
 }
-export const PAGE_match_id_ab = (id: (Parameters<typeof import('../params/ab.ts').match>[0]), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
+export const PAGE_match_id_ab = (id: (ParamMatcherParam<typeof import('../params/ab.ts').match>), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
   return `${params?.lang ? `/${params?.lang}`: ''}/match/${id}`
 }
 export const PAGE_match_id_int = (id: (number), params?: { lang?: ('fr' | 'en' | 'hu' | 'at' | string) }) => {
@@ -174,6 +174,9 @@ function StringOrUndefined(val: any) {
 
   return String(val)
 }
+
+type ParamMatcherParam<T extends (...args: any) => any> = ExtractParam<Parameters<T>[0]>;
+type ExtractParam<T> = T extends `${number}` ? number : T;
 
 /**
 * Add this type as a generic of the vite plugin `kitRoutes<KIT_ROUTES>`.

--- a/packages/vite-plugin-kit-routes/src/test/ROUTES_post-update.ts
+++ b/packages/vite-plugin-kit-routes/src/test/ROUTES_post-update.ts
@@ -28,10 +28,10 @@ const PAGES = {
   "/main": (params?: { lang?: (string | number) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/main`
   },
-  "/match/[id=ab]": (params: { id: (Parameters<typeof import('../params/ab.ts').match>[0]), lang?: (string | number) }) => {
+  "/match/[id=ab]": (params: { id: (ParamMatcherParam<typeof import('../params/ab.ts').match>), lang?: (string | number) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/match/${params.id}`
   },
-  "/match/[id=int]": (params: { id: (Parameters<typeof import('../params/int.ts').match>[0]), lang?: (string | number) }) => {
+  "/match/[id=int]": (params: { id: (ParamMatcherParam<typeof import('../params/int.ts').match>), lang?: (string | number) }) => {
     return `${params?.lang ? `/${params?.lang}`: ''}/match/${params.id}`
   },
   "/site": (params?: { lang?: (string | number) }) => {
@@ -190,6 +190,9 @@ export function route<T extends keyof AllTypes>(key: T, ...params: any[]): strin
     return AllObjs[key] as string
   }
 }
+
+type ParamMatcherParam<T extends (...args: any) => any> = ExtractParam<Parameters<T>[0]>;
+type ExtractParam<T> = T extends `${number}` ? number : T;
 
 /**
 * Add this type as a generic of the vite plugin `kitRoutes<KIT_ROUTES>`.

--- a/packages/vite-plugin-kit-routes/vite.config.ts
+++ b/packages/vite-plugin-kit-routes/vite.config.ts
@@ -112,6 +112,8 @@ export default defineConfig({
       override_params: {
         lang: { type: "'fr' | 'en' | 'hu' | 'at' | string" },
       },
+
+      override_matcher_params: ['number'],
     }),
   ],
   test: {


### PR DESCRIPTION
In my project I use matchers like this:

```ts
export const match = (param: `${number}`): param is `${number}` => /^\d+$/.test(param);
```

But the types for the generated function wants me to always do `number.toString()`. With this change also straight numbers are allowed if configured.
The option accepts any valid type.

More in-depth explanation from the code:
![image](https://github.com/jycouet/kitql/assets/9959940/6ac47ff5-a426-40a3-a65b-50e5fcf59fbc)
