### PR TITLE
replace colons in route identifiers

### DIFF
--- a/.changeset/tough-bees-smoke.md
+++ b/.changeset/tough-bees-smoke.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-kit-routes': minor
+---
+
+Replace colons in path identifiers

--- a/packages/vite-plugin-kit-routes/src/lib/plugin.ts
+++ b/packages/vite-plugin-kit-routes/src/lib/plugin.ts
@@ -282,7 +282,7 @@ export function formatKey(key: string, o: Options) {
     return toRet
   }
 
-  const toReplace = ['/', '[', ']', '(', ')', '-', '=', '.']
+  const toReplace = ['/', '[', ']', '(', ')', '-', '=', '.', ':']
   toRet = toRet
     .split('')
     .map(c => (toReplace.includes(c) ? '_' : c))


### PR DESCRIPTION
In my project I have some routes like `/admin/things/id:123`. This `:` is not replaced so that the generated code looks like a type specification: 

![image](https://github.com/jycouet/kitql/assets/9959940/a1ba7468-1998-4c33-922c-532191f566b9)

This PR fixes the problem by also replacing `:`s with `_`s.