### PR TITLE
feat: exporting AllObjs from generated ROUTES.ts

### DIFF
--- a/packages/vite-plugin-kit-routes/src/lib/format.ts
+++ b/packages/vite-plugin-kit-routes/src/lib/format.ts
@@ -81,7 +81,7 @@ type NonFunctionKeys<T> = { [K in keyof T]: T[K] extends Function ? never : K }[
 type FunctionKeys<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T]
 type FunctionParams<T> = T extends (...args: infer P) => any ? P : never
 
-const AllObjs = { ...PAGES, ...ACTIONS, ...SERVERS, ...LINKS }
+export const AllObjs = { ...PAGES, ...ACTIONS, ...SERVERS, ...LINKS }
 type AllTypes = typeof AllObjs
 
 /**


### PR DESCRIPTION
This allows users to import 'AllObjs' which contains all routes.

Related Issue: #675 