### PR TITLE
kit-routes: add exportConsts config option

### DIFF
--- a/packages/vite-plugin-kit-routes/src/lib/plugin.ts
+++ b/packages/vite-plugin-kit-routes/src/lib/plugin.ts
@@ -62,6 +62,13 @@ export type Options<T extends RouteMappings = RouteMappings> = {
      */
     stats?: boolean
   }
+  
+  /**
+   * Export ROUTES, LINKS, SERVERS and ACTIONS constants in the generated file
+   * Does nothing when the format is "variables", as exporting is required then.
+   * @default false
+   */
+  exportObjects?: boolean
 
   /**
    * @default 'src/lib/ROUTES.ts'
@@ -915,7 +922,7 @@ ${c.files
             .map((c) => {
               return (
                 `/**\n * ${c.type}\n */
-${options?.format?.includes('object') ? `export ` : ``}` +
+${options?.exportObjects || options?.format?.includes('object') ? `export ` : ``}` +
                 `const ${c.type} = {
   ${c.files
     .map((key) => {


### PR DESCRIPTION
Hi!

We're using kit-routes in our app and it works great!

However, we have users that can choose the username, and get the profile page on `/username`. Thus, we want to disallow usernames that conflict with existing routes, so that their profile page is not inaccessible because they chose e.g. "settings" as a username

kit-routes actually generates the strings we need for this! unfortunately, they're not exported...

right now I'm using a yarn patch to get them, but having it in the config will certainly be better ^^

So this PR adds the `exportConsts` option that decides whether to export `PAGES`, etc. or not