### PR TITLE
feat(kit-routes)!: Avoid escaping string and array default values

### DIFF
--- a/.changeset/early-pugs-thank.md
+++ b/.changeset/early-pugs-thank.md
@@ -2,11 +2,11 @@
 'vite-plugin-kit-routes': major
 ---
 
-feat!: Avoid requiring string default values to be quoted
+feat(kit-routes)!: Avoid escaping string and array default values
 
 This change simplifies setting default values for path and search parameters.
-Previously, you had to douple-escape a default string value. 
-Now, you can simply set a string default value like any other data type:
+Previously, you had to douple-escape a default string or array value. 
+Now, you can simply set the default values like any other data type:
 
 ```diff
  kitRoutes({
@@ -14,9 +14,14 @@ Now, you can simply set a string default value like any other data type:
      '/[org]/[project]/sessions': {
        explicit_search_params: {
 -         timeFrame: { type: 'string', default: "'1d'" }
+-         userId: { type: 'Array<string>', default: "['123', 'abc']" }
 +         timeFrame: { type: 'string', default: '1d' }
++         userId: { type: 'Array<string>', default: ['123', 'abc'] }
        }
      }
    }
  })
 ```
+
+This is a breaking change! To migrate to the new version, remove the quotes
+to escape string and array values as shown in the example above.

--- a/.changeset/early-pugs-thank.md
+++ b/.changeset/early-pugs-thank.md
@@ -1,0 +1,22 @@
+---
+'vite-plugin-kit-routes': major
+---
+
+feat!: Avoid requiring string default values to be quoted
+
+This change simplifies setting default values for path and search parameters.
+Previously, you had to douple-escape a default string value. 
+Now, you can simply set a string default value like any other data type:
+
+```diff
+ kitRoutes({
+   PAGES: {
+     '/[org]/[project]/sessions': {
+       explicit_search_params: {
+-         timeFrame: { type: 'string', default: "'1d'" }
++         timeFrame: { type: 'string', default: '1d' }
+       }
+     }
+   }
+ })
+```

--- a/packages/vite-plugin-kit-routes/src/lib/ROUTES.ts
+++ b/packages/vite-plugin-kit-routes/src/lib/ROUTES.ts
@@ -74,7 +74,7 @@ const PAGES = {
 		hash: 'section0' | 'section1' | 'section2' | 'section3'
 		anotherOne?: string
 	}) => {
-		params['hash'] = params['hash'] ?? 'section0'
+		params['hash'] = params['hash'] ?? '"section0"'
 		return `/anchors${appendSp({ anotherOne: params['anotherOne'], __KIT_ROUTES_ANCHOR__: params['hash'] })}`
 	},
 	'/anchors/[id]': (params: {

--- a/packages/vite-plugin-kit-routes/src/lib/ROUTES.ts
+++ b/packages/vite-plugin-kit-routes/src/lib/ROUTES.ts
@@ -74,7 +74,7 @@ const PAGES = {
 		hash: 'section0' | 'section1' | 'section2' | 'section3'
 		anotherOne?: string
 	}) => {
-		params['hash'] = params['hash'] ?? '"section0"'
+		params['hash'] = params['hash'] ?? 'section0'
 		return `/anchors${appendSp({ anotherOne: params['anotherOne'], __KIT_ROUTES_ANCHOR__: params['hash'] })}`
 	},
 	'/anchors/[id]': (params: {

--- a/packages/vite-plugin-kit-routes/src/lib/plugin.ts
+++ b/packages/vite-plugin-kit-routes/src/lib/plugin.ts
@@ -284,12 +284,12 @@ export type OverrideParam = {
 export type ExtendParam = {
 	type?: string
 	/**
-	 * You have to double escape strings.
+	 * Default value for the param
 	 *
 	 * @example
 	 * { type: 'number', default: 75 }
-	 * of
-	 * { type: 'string', default: '"jycouet"' }
+	 * or
+	 * { type: 'string', default: 'jycouet' }
 	 */
 	default?: any
 }

--- a/packages/vite-plugin-kit-routes/src/lib/plugin.ts
+++ b/packages/vite-plugin-kit-routes/src/lib/plugin.ts
@@ -582,7 +582,7 @@ export function buildMetadata(
 						paramsFromPath[i].type = sp[1].type
 					}
 					if (sp[1] && sp[1].default !== undefined) {
-						paramsFromPath[i].default = sp[1].default
+						paramsFromPath[i].default = JSON.stringify(sp[1].default)
 						// It's becoming optional because it has a default
 						paramsFromPath[i].optional = true
 					}
@@ -639,7 +639,7 @@ export function buildMetadata(
 			hash: {
 				type: customConf.hash.type,
 				required: customConf.hash.required,
-				default: customConf.hash.default,
+				default: customConf.hash.default && JSON.stringify(customConf.hash.default),
 				// @ts-expect-error
 				isAnchor: true,
 			},
@@ -656,7 +656,7 @@ export function buildMetadata(
 				name: sp[0],
 				optional: !sp[1].required,
 				type: sp[1].type,
-				default: sp[1].default,
+				default: sp[1].default && JSON.stringify(sp[1].default),
 				isArray: false,
 				// @ts-expect-error
 				isAnchor: sp[1].isAnchor,

--- a/packages/vite-plugin-kit-routes/src/lib/plugin.ts
+++ b/packages/vite-plugin-kit-routes/src/lib/plugin.ts
@@ -639,7 +639,7 @@ export function buildMetadata(
 			hash: {
 				type: customConf.hash.type,
 				required: customConf.hash.required,
-				default: customConf.hash.default && JSON.stringify(customConf.hash.default),
+				default: customConf.hash.default,
 				// @ts-expect-error
 				isAnchor: true,
 			},

--- a/packages/vite-plugin-kit-routes/src/lib/plugins.spec.ts
+++ b/packages/vite-plugin-kit-routes/src/lib/plugins.spec.ts
@@ -261,8 +261,8 @@ describe('fileToMetadata', () => {
 					subscriptions_snapshot_id: {
 						explicit_search_params: { limit: { type: 'number' } },
 						params: {
-							snapshot: { type: 'string', default: '"snapshot"' },
-							id: { type: 'string', default: '"id"' },
+							snapshot: { type: 'string', default: 'snapshot' },
+							id: { type: 'string', default: 'id' },
 						},
 					},
 				},
@@ -544,7 +544,7 @@ describe('run()', async () => {
 				href: 'https://www.gravatar.com/avatar/[str]',
 				explicit_search_params: {
 					s: { type: 'number', default: 75 },
-					d: { type: '"retro" | "identicon"', default: '"identicon"' },
+					d: { type: '"retro" | "identicon"', default: 'identicon' },
 				},
 			},
 		},
@@ -579,8 +579,8 @@ describe('run()', async () => {
 					'da-sh': { type: 'string' },
 				},
 				params: {
-					id: { type: 'string', default: '"Vienna"' },
-					lang: { type: "'fr' | 'hu' | undefined", default: '"fr"' },
+					id: { type: 'string', default: 'Vienna' },
+					lang: { type: "'fr' | 'hu' | undefined", default: 'fr' },
 				},
 			},
 			match_id_int: {
@@ -621,7 +621,7 @@ describe('run()', async () => {
 			},
 			send_site_contract_siteId_contractId: {
 				explicit_search_params: {
-					extra: { type: "'A' | 'B'", default: '"A"' },
+					extra: { type: "'A' | 'B'", default: 'A' },
 				},
 			},
 		},

--- a/packages/vite-plugin-kit-routes/vite.config.ts
+++ b/packages/vite-plugin-kit-routes/vite.config.ts
@@ -49,8 +49,8 @@ export const _kitRoutesConfig: Options<KIT_ROUTES> = {
 				'da-sh': { type: 'string' },
 			},
 			params: {
-				id: { type: 'string', default: '"Vienna"' },
-				lang: { type: "'fr' | 'hu' | undefined", default: '"fr"' },
+				id: { type: 'string', default: 'Vienna' },
+				lang: { type: "'fr' | 'hu' | undefined", default: 'fr' },
 			},
 		},
 		'/match/[id=int]': {
@@ -76,7 +76,7 @@ export const _kitRoutesConfig: Options<KIT_ROUTES> = {
 			hash: {
 				type: '"section0" | "section1" | "section2" | "section3"',
 				required: true,
-				default: '"section0"',
+				default: 'section0',
 			},
 		},
 		'/anchors/[id]': {
@@ -99,7 +99,7 @@ export const _kitRoutesConfig: Options<KIT_ROUTES> = {
 		},
 		'send /site_contract/[siteId]-[contractId]': {
 			explicit_search_params: {
-				extra: { type: "'A' | 'B'", default: '"A"' },
+				extra: { type: "'A' | 'B'", default: 'A' },
 			},
 		},
 		'create /site': {
@@ -123,7 +123,7 @@ export const _kitRoutesConfig: Options<KIT_ROUTES> = {
 			},
 			explicit_search_params: {
 				s: { type: 'number', default: 75 },
-				d: { type: '"retro" | "identicon"', default: '"identicon"' },
+				d: { type: '"retro" | "identicon"', default: 'identicon' },
 			},
 		},
 	},


### PR DESCRIPTION
**This is a breaking change!**

This PR introduces a simplification for setting default values for parameters: Previously, you had to escape string and array values with a double quote. With this change, they can simply be specified like a normal string

```diff
 kitRoutes({
   PAGES: {
     '/[org]/[project]/sessions': {
       explicit_search_params: {
-         timeFrame: { type: 'string', default: "'1d'" }
-         userId: { type: 'Array<string>', default: "['123', 'abc']" }
+         timeFrame: { type: 'string', default: '1d' }
+         userId: { type: 'Array<string>', default: ['123', 'abc'] }
       }
     }
   }
 })
```

This applies to all properties in the kit routes options where you can specify default values (e.g. path, search params and hashes). I implemented this change by calling `JSON.stringify` on the default values instead of 1:1 serializing the passed values.

Regarding tests: I think we should be good given that all existing tests pass and the `ROUTES.ts` file didn't change, despite removing all double quotes from the vite config. Happy to add a test if you want to see something else tested specifically!

UPDATE: I noticed the change didn't only apply to string values but also to arrays, so I changed the PR title and description to generalize it a bit more.

closes #1014  