### PR TITLE
fix: break helpers/eslint-config dep cycle, pin esrap

### DIFF
--- a/.changeset/fix-circular-dep-and-esrap.md
+++ b/.changeset/fix-circular-dep-and-esrap.md
@@ -1,0 +1,7 @@
+---
+'@kitql/eslint-config': patch
+'@kitql/internals': patch
+'@kitql/helpers': patch
+---
+
+break the `@kitql/helpers` <-> `@kitql/eslint-config` workspace dependency cycle, and make sure `esrap` ships as a pinned version (no `pkg.pr.new` url)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "catalog:lib-author-helper",
     "@changesets/cli": "catalog:lib-author-helper",
+    "@kitql/eslint-config": "workspace:*",
     "@vitest/coverage-v8": "catalog:testing",
     "esbuild": "catalog:tooling",
     "eslint": "catalog:linting",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -37,7 +37,6 @@
     "@sveltejs/adapter-auto": "catalog:sveltekit",
     "@sveltejs/kit": "catalog:sveltekit",
     "@sveltejs/package": "catalog:sveltekit",
-    "@kitql/eslint-config": "workspace:*",
     "@sveltejs/vite-plugin-svelte": "catalog:sveltekit",
     "@typescript/native-preview": "catalog:tooling",
     "publint": "catalog:lib-author-helper",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       '@changesets/cli':
         specifier: catalog:lib-author-helper
         version: 2.31.0(@types/node@24.12.0)
+      '@kitql/eslint-config':
+        specifier: workspace:*
+        version: link:packages/eslint-config
       '@vitest/coverage-v8':
         specifier: catalog:testing
         version: 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
@@ -379,7 +382,7 @@ importers:
         version: 5.55.0
       svelte-check:
         specifier: catalog:svelte
-        version: 4.4.5(picomatch@4.0.4)(svelte@5.55.0)(typescript@5.9.2)
+        version: 4.4.5(picomatch@4.0.3)(svelte@5.55.0)(typescript@5.9.2)
       tslib:
         specifier: catalog:lib-author-helper
         version: 2.8.0
@@ -397,9 +400,6 @@ importers:
         specifier: catalog:lib-dep-publish
         version: 1.2.2
     devDependencies:
-      '@kitql/eslint-config':
-        specifier: workspace:*
-        version: link:../eslint-config
       '@sveltejs/adapter-auto':
         specifier: catalog:sveltekit
         version: 7.0.0(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.0)(vite@8.0.10(@types/node@24.12.0)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.85.1)(terser@5.37.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.55.0)(typescript@5.9.2)(vite@8.0.10(@types/node@24.12.0)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.85.1)(terser@5.37.0)(tsx@4.21.0)(yaml@2.8.2)))
@@ -3927,10 +3927,6 @@ packages:
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
-  lru-cache@11.2.2:
-    resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
-    engines: {node: 20 || >=22}
-
   lru-cache@11.3.6:
     resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
     engines: {node: 20 || >=22}
@@ -5545,7 +5541,7 @@ snapshots:
       '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
-      lru-cache: 11.2.2
+      lru-cache: 11.3.6
     optional: true
 
   '@asamuzakjp/dom-selector@6.7.4':
@@ -5554,7 +5550,7 @@ snapshots:
       bidi-js: 1.0.3
       css-tree: 3.1.0
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.2.2
+      lru-cache: 11.3.6
     optional: true
 
   '@asamuzakjp/nwsapi@2.3.9':
@@ -8964,9 +8960,6 @@ snapshots:
   lower-case@2.0.2:
     dependencies:
       tslib: 2.8.1
-
-  lru-cache@11.2.2:
-    optional: true
 
   lru-cache@11.3.6: {}
 


### PR DESCRIPTION
## What

- **Circular dep:** `@kitql/helpers` devDepended on `@kitql/eslint-config`, which depends back on `@kitql/helpers` - CI logged `WARN There are cyclic workspace dependencies` on every run. Moved the `@kitql/eslint-config` devDep to the root `package.json`; `kitql-lint` still resolves from the root `node_modules/.bin`, so per-package `lint`/`format` keep working.
- **esrap:** the `pkg.pr.new` esrap URL is already gone from the repo (catalog pins `2.2.6`); changeset bumps `@kitql/internals` so a release ships with esrap pinned, not the ephemeral `pkg.pr.new` url that leaked into `@kitql/internals@0.11.0`.

## Verified (fresh install in a worktree)

- `pnpm install --frozen-lockfile`: 0 cyclic warnings (was present before)
- `helpers`: build / lint / check / test:ci all green
- `eslint-config`, `internals`: build + lint green

🤖 Generated with [Claude Code](https://claude.com/claude-code)